### PR TITLE
refactor code to anticipate joint modeling work

### DIFF
--- a/survivalstan/survivalstan.py
+++ b/survivalstan/survivalstan.py
@@ -111,7 +111,7 @@ def fit_stan_survival_model(df=None,
 
     
     if make_inits:
-        kwargs = dict(kwargs, init = make_inits(input_data))
+        kwargs = dict(kwargs, init = make_inits(input_data.data))
     
     survival_fit = FIT_FUN(
         model_code = model_code,
@@ -143,7 +143,7 @@ def fit_stan_survival_model(df=None,
                                            grp_coef_type=grp_coef_type,
                                            grp_names=grp_names,
                                            columns=x_df.columns,
-                                           input_data=input_data,
+                                           input_data=input_data.data,
                                            model_cohort=model_cohort
                                           )
         except:

--- a/survivalstan/survivalstan.py
+++ b/survivalstan/survivalstan.py
@@ -311,7 +311,7 @@ class SurvivalStanData:
             self.df_nonmiss[self.group_id_col] = self.df_nonmiss[self.group_col].astype('category').cat.codes + 1
 
     def get_group_names(self):
-        if not self.self_group_id_col:
+        if not self.group_id_col:
             return(None)
         
         # which column should describe group names


### PR DESCRIPTION
Changes in this PR:

1. pull data-prep into a separate class: `SurvivalStanData`. Preparation of these data is done via that class's `__init__` method. 
    - is a class because meta-data about the processing step (e.g. coefficient names, etc) are needed in the fit-stan object to support variety of post-processing.
2. new parameter `input_data`, allowing user to prepare the SurvivalStanData object separately & pass in as an argument.
3. minor bugfix for case where data are provided in "long" format & contain only a single failure time.
