### PR TITLE
Add numexpr to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ stanity>=0.1.2
 pystan>=2.12.0
 lifelines
 versioneer
+numexpr>=2.6.1


### PR DESCRIPTION
Needed for `pandas` `query` but not installed by `pandas` by default.